### PR TITLE
Check if the exported_fields array has empty keys

### DIFF
--- a/code/ExcelImportExport.php
+++ b/code/ExcelImportExport.php
@@ -59,7 +59,16 @@ class ExcelImportExport
         if ($unexportedFields) {
             $exportedFields = array_diff($exportedFields, $unexportedFields);
         }
-        return array_combine($exportedFields, $exportedFields);
+        
+        $fields = [];
+        foreach ($exportedFields as $key => $value) {
+            if (is_int($key)) {
+                $key = $value;
+            }
+            $fields[$key] = $value;
+        }
+
+        return $fields;
     }
 
     /**


### PR DESCRIPTION
By checking for empty keys it becomes possible to set your own column headers like
```php
private static $exported_fields = [
        'Field' => 'Header'
];
```
instead of only supporting
```php
private static $exported_fields = [
        'Field'
];
```