### PR TITLE
Add extra headers to prevent caching

### DIFF
--- a/src/ExcelGridFieldExportButton.php
+++ b/src/ExcelGridFieldExportButton.php
@@ -184,7 +184,10 @@ class ExcelGridFieldExportButton implements
                 $func = $this->afterExportCallback;
                 $func();
             }
-
+            
+            header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+            header("Cache-Control: post-check=0, pre-check=0", false);
+            header("Pragma: no-cache");
             header('Content-type: application/vnd.ms-excel');
             header('Content-Disposition: attachment; filename="' . $fileName . '"');
 


### PR DESCRIPTION
We experience have caching issues with the excel export button. By adding anti cache headers these can be solved.
Other solution is to add to main .htaccess mod_expires section: ExpiresByType application/vnd.ms-excel "now"